### PR TITLE
Metric Collection broken with multiple thermostats

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -218,35 +218,34 @@ func (c *eCollector) Collect(ch chan<- prometheus.Metric) {
 				}
 			}
 		}
-		statSummary, err := c.client.GetThermostatSummary(ecobee.Selection{
-			SelectionType:          "registered",
-			IncludeEquipmentStatus: true,
-			IncludeAlerts:          true,
-		})
-		if err != nil {
-			log.Error(err)
-			return
-		}
-		// sAttr := []string{"HeatPump", "HeatPump2", "HeatPump3", "CompCool1", "CompCool2", "AuxHeat1", "AuxHeat2", "AuxHeat3", "Fan", "Humidifier", "Dehumidifier", "Ventilator", "Economizer", "CompHotWater", "AuxHotWater"}
-		sAttr := []string{"CompCool1", "AuxHeat1", "Fan"}
-		for _, s := range statSummary {
-			if s.Connected {
-				r := reflect.ValueOf(s)
-				for _, a := range sAttr {
-					f := reflect.Indirect(r).FieldByName(a)
-					switch f.Bool() {
-					case true:
-						ch <- prometheus.MustNewConstMetric(
-							c.hvacInOperation, prometheus.GaugeValue, 1, s.Identifier, s.Name, a,
-						)
-					case false:
-						ch <- prometheus.MustNewConstMetric(
-							c.hvacInOperation, prometheus.GaugeValue, 0, s.Identifier, s.Name, a,
-						)
-					}
+	}
+	statSummary, err := c.client.GetThermostatSummary(ecobee.Selection{
+		SelectionType:          "registered",
+		IncludeEquipmentStatus: true,
+		IncludeAlerts:          true,
+	})
+	if err != nil {
+		log.Error(err)
+		return
+	}
+	// sAttr := []string{"HeatPump", "HeatPump2", "HeatPump3", "CompCool1", "CompCool2", "AuxHeat1", "AuxHeat2", "AuxHeat3", "Fan", "Humidifier", "Dehumidifier", "Ventilator", "Economizer", "CompHotWater", "AuxHotWater"}
+	sAttr := []string{"CompCool1", "AuxHeat1", "Fan"}
+	for _, s := range statSummary {
+		if s.Connected {
+			r := reflect.ValueOf(s)
+			for _, a := range sAttr {
+				f := reflect.Indirect(r).FieldByName(a)
+				switch f.Bool() {
+				case true:
+					ch <- prometheus.MustNewConstMetric(
+						c.hvacInOperation, prometheus.GaugeValue, 1, s.Identifier, s.Name, a,
+					)
+				case false:
+					ch <- prometheus.MustNewConstMetric(
+						c.hvacInOperation, prometheus.GaugeValue, 0, s.Identifier, s.Name, a,
+					)
 				}
 			}
 		}
 	}
-
 }


### PR DESCRIPTION
Pull additional metric collection out of loop - causes duplicate failures with multiple thermostats.

For example:
`curl -X GET http://localhost:9099/metrics
An error has occurred while serving metrics:

30 error(s) occurred:
* collected metric "ecobee_hvac_in_operation" { label:<name:"equipment" value:"HeatPump" > label:<name:"thermostat_id" value:"522653xxxxxx" > label:<name:"thermostat_name" value:"Dining Room" > gauge:<value:0 > } was collected before with the same name and label values
* collected metric "ecobee_hvac_in_operation" { label:<name:"equipment" value:"HeatPump2" > label:<name:"thermostat_id" value:"522653xxxxxx" > label:<name:"thermostat_name" value:"Dining Room" > gauge:<value:0 > } was collected before with the same name and label values
* collected metric "ecobee_hvac_in_operation" { label:<name:"equipment" value:"HeatPump3" > label:<name:"thermostat_id" value:"522653xxxxxx" > label:<name:"thermostat_name" value:"Dining Room" > gauge:<value:0 > } was collected before with the same name and label values`